### PR TITLE
Buster dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: autoversion
 Section: misc
 Priority: optional
-Maintainer: Liraz Siri <liraz@turnkeylinux.org>
+Maintainer: Jeremy Davis <jeremy@turnkeylinux.org>
 Build-Depends:
  debhelper (>= 10),
  pyproject-common,

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ X-Python-Version: >= 2.6
 Package: autoversion
 Architecture: any
 Depends:
- git-core (>= 1:1.5.2) | git
+ git-core (>= 1:1.5.2) | git (>= 1:2.1.4),
  ${misc:Depends},
  ${shlibs:Depends},
  ${python:Depends},

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ X-Python-Version: >= 2.6
 Package: autoversion
 Architecture: any
 Depends:
- git-core (>= 1:1.5.2) | git (>= 1:2.1.4),
+ git (>= 1:2.1.4),
  ${misc:Depends},
  ${shlibs:Depends},
  ${python:Depends},

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ X-Python-Version: >= 2.6
 Package: autoversion
 Architecture: any
 Depends:
- git-core (>= 1:1.5.2),
+ git-core (>= 1:1.5.2) | git
  ${misc:Depends},
  ${shlibs:Depends},
  ${python:Depends},


### PR DESCRIPTION
Minor modification to dependencies for v16.x (Debian 10/Buster based). Backwards compatible with v15.x (Debian 9/Stretch based).