### PR TITLE
Improve error handling - show msg rather than stacktrace.

### DIFF
--- a/autoversion
+++ b/autoversion
@@ -14,6 +14,7 @@ import sys
 import argparse
 
 import autoversion_lib as autoversion
+from autoversion_lib import AutoverError
 
 EXAMPLES = """Example usage:
     autoversion HEAD                    # print latest version
@@ -56,7 +57,10 @@ def main():
         help="any revision supported by git (e.g.," "commit ids, tags, refs, etc.)",
     )
     args = parser.parse_args()
-    auto_ver = autoversion.Autoversion(os.getcwd(), precache=args.reverse)
+    try:
+        auto_ver = autoversion.Autoversion(os.getcwd(), precache=args.reverse)
+    except AutoverError as e:
+        fatal(e)
     if args.reverse:
         print(auto_ver.version2commit(args.commit))
     else:

--- a/autoversion_lib/__init__.py
+++ b/autoversion_lib/__init__.py
@@ -159,7 +159,7 @@ class Autoversion:
         try:
             git = Git(path)
         except GitError as e:
-            raise AutoverError(e)
+            raise AutoverError(f"failed to initialize gitwrapper: {e}") from e
 
         self.timestamps = Timestamps(git, precache)
         precache_commits = self.timestamps.precache_commits

--- a/autoversion_lib/__init__.py
+++ b/autoversion_lib/__init__.py
@@ -14,7 +14,7 @@ from calendar import timegm
 import urllib.parse
 from typing import Optional, List, Tuple, Dict, Generator
 
-from gitwrapper import Git
+from gitwrapper import Git, GitError
 
 
 class AutoverError(Exception):
@@ -156,7 +156,10 @@ class Timestamps:
 
 class Autoversion:
     def __init__(self, path: str, precache: bool=False):
-        git = Git(path)
+        try:
+            git = Git(path)
+        except GitError as e:
+            raise AutoverError(e)
 
         self.timestamps = Timestamps(git, precache)
         precache_commits = self.timestamps.precache_commits


### PR DESCRIPTION
This is fairly minor adjustment which makes the output better when run outside a git dir.

E.g.:
Prior to this change:
```
# autoversion HEAD
Traceback (most recent call last):
  File "/usr/bin/autoversion", line 67, in <module>
    main()
  File "/usr/bin/autoversion", line 59, in main
    auto_ver = autoversion.Autoversion(os.getcwd(), precache=args.reverse)
  File "/usr/lib/python3.9/dist-packages/autoversion_lib/__init__.py", line 159, in __init__
    git = Git(path)
  File "/usr/lib/python3/dist-packages/gitwrapper/__init__.py", line 171, in __init__
    raise GitError("Not a git repository `%s'" % self.path)
gitwrapper.GitError: Not a git repository `/turnkey/public/just-a-dir'
```
After this change:
```
# autoversion HEAD
error: Not a git repository `/turnkey/public/just-a-dir'
```

@OnGle 