### PR TITLE
Tweaks

### DIFF
--- a/autoversion
+++ b/autoversion
@@ -18,7 +18,8 @@ import autoversion_lib as autoversion
 from autoversion_lib import AutoverError
 
 EXAMPLES = """Example usage:
-    autoversion                         # print latest version (uses 'HEAD' by default)
+    autoversion                         # print latest version (uses 'HEAD' \
+by default)
     autoversion 9497a28                 # print version at commit ID 9497a28
     autoversion -r v1.0                 # print commit ID of version v1.0
     autoversion $(git-rev-list --all)   # print all versions
@@ -70,7 +71,8 @@ def main():
     if args.reverse:
         print(auto_ver.version2commit(args.commit))
     else:
-        print(auto_ver.commit2version(resolve_committish(auto_ver.git, args.commit)))
+        print(auto_ver.commit2version(
+            resolve_committish(auto_ver.git, args.commit)))
 
 
 if __name__ == "__main__":

--- a/autoversion
+++ b/autoversion
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 import argparse
+from typing import NoReturn
 
 import autoversion_lib as autoversion
 from autoversion_lib import AutoverError
@@ -23,12 +24,13 @@ EXAMPLES = """Example usage:
 """
 
 
-def fatal(msg):
+def fatal(msg: str) -> NoReturn:
     print("error: " + str(msg), file=sys.stderr)
     sys.exit(1)
 
 
-def resolve_committish(git, committish):
+def resolve_committish(git: autoversion.Git,
+                       committish: str) -> str:
     # skip expensive git-rev-parse if given a full commit id
     if re.match("[0-9a-f]{40}$", committish):
         return committish

--- a/autoversion
+++ b/autoversion
@@ -18,8 +18,9 @@ import autoversion_lib as autoversion
 from autoversion_lib import AutoverError
 
 EXAMPLES = """Example usage:
-    autoversion HEAD                    # print latest version
-    autoversion -r v1.0                 # print commit of version v1.0
+    autoversion                         # print latest version (uses 'HEAD' by default)
+    autoversion 9497a28                 # print version at commit ID 9497a28
+    autoversion -r v1.0                 # print commit ID of version v1.0
     autoversion $(git-rev-list --all)   # print all versions
 """
 
@@ -37,14 +38,14 @@ def resolve_committish(git: autoversion.Git,
 
     commit = git.rev_parse(committish)
     if commit is None:
-        fatal("invalid committish `%s'" % committish)
+        fatal(f"invalid committish `{committish}'")
     return commit
 
 
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="Map git commits to auto" "-versions and vice versa",
+        description="Map git commits to auto-versions and vice versa",
         epilog=EXAMPLES,
     )
     parser.add_argument(
@@ -56,7 +57,10 @@ def main():
     )
     parser.add_argument(
         "commit",
-        help="any revision supported by git (e.g.," "commit ids, tags, refs, etc.)",
+        nargs='?',
+        default='HEAD',
+        help=("any revision supported by git (e.g. commit ids, tags, refs,"
+              "etc.) Default if not set: HEAD"),
     )
     args = parser.parse_args()
     try:

--- a/autoversion_lib/__init__.py
+++ b/autoversion_lib/__init__.py
@@ -14,7 +14,7 @@ from calendar import timegm
 import urllib.parse
 from typing import Optional, Generator
 
-from gitwrapper import Git, GitError
+from gitwrapper import Git, GitError  # type: ignore
 
 
 class AutoverError(Exception):

--- a/autoversion_lib/__init__.py
+++ b/autoversion_lib/__init__.py
@@ -12,7 +12,7 @@ import re
 from time import gmtime
 from calendar import timegm
 import urllib.parse
-from typing import Optional, List, Tuple, Dict, Generator
+from typing import Optional, Generator
 
 from gitwrapper import Git, GitError
 
@@ -25,7 +25,7 @@ class Describes:
     """Class that maps git describes to git commits and vice versa"""
 
     def _get_describes_commits(
-            self, commits: Optional[List[str]]=None) -> List[Tuple[str, str]]:
+            self, commits: Optional[list[str]]=None) -> list[tuple[str, str]]:
         if commits is None:
             commits = self.git.rev_list("--all")
 
@@ -34,11 +34,11 @@ class Describes:
 
     def __init__(self,
             git: Git, precache: bool=False,
-            precache_commits: Optional[List[str]]=None):
+            precache_commits: Optional[list[str]]=None):
         self.git = git
 
-        self.map_describes_commits: Optional[Dict[str, str]]
-        self.map_commits_describes: Optional[Dict[str, str]]
+        self.map_describes_commits: Optional[dict[str, str]]
+        self.map_commits_describes: Optional[dict[str, str]]
 
         if precache:
             describes_commits = self._get_describes_commits(precache_commits)
@@ -75,8 +75,8 @@ class Shorts:
 
     def _get_commit_shorts(
             self, shortlen: int,
-            commits: Optional[List[str]]=None
-    ) -> Generator[Tuple[str, str], None, None]:
+            commits: Optional[list[str]]=None
+    ) -> Generator[tuple[str, str], None, None]:
         if commits is None:
             commits = self.git.rev_list("--all")
 
@@ -85,16 +85,16 @@ class Shorts:
 
     def __init__(
             self, git: Git, precache: bool=False,
-            precache_commits: Optional[List[str]] = None,
+            precache_commits: Optional[list[str]] = None,
             precache_shortlen: int=8):
         self.git = git
 
-        self.precache: Dict[str, Optional[str]]
+        self.precache: dict[str, Optional[str]]
 
         if precache:
             keyvals = self._get_commit_shorts(precache_shortlen, precache_commits)
 
-            precache_: Dict[str, Optional[str]]
+            precache_: dict[str, Optional[str]]
             # don't resolve ambigious values (assign None to doubles)
             precache_ = {}
             for key, val in keyvals:
@@ -122,7 +122,7 @@ class Shorts:
 class Timestamps:
     """Class that maps git commits to timestamps"""
 
-    def _get_commit_timestamps(self) -> Generator[Tuple[str, int], None, None]:
+    def _get_commit_timestamps(self) -> Generator[tuple[str, int], None, None]:
         lines = self.git.rev_list("--pretty=format:%at", "--all")
         for i in range(0, len(lines), 2):
             commit = lines[i]
@@ -135,8 +135,8 @@ class Timestamps:
 
     def __init__(self, git: Git, precache: bool=False):
         self.git = git
-        self.precache: Dict[str, int] = {}
-        self.precache_commits: List[str] = []
+        self.precache: dict[str, int] = {}
+        self.precache_commits: list[str] = []
         if precache:
             commit_timestamps = self._get_commit_timestamps()
             for commit, timestamp in commit_timestamps:

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Standards-Version: 4.0.0
 X-Python-Version: >= 3.5
 
 Package: autoversion
-Architecture: any
+Architecture: all
 Depends:
  git (>= 1:2.1.4),
  ${misc:Depends},


### PR DESCRIPTION
Grab bag of tweaks and improvements.

Change package arch from `any` to `all` - difference is that `any` is built for each and every supported arch, whereas `all` is built once for all arches.

Typing updates/improvements, plus code styling to make pep8 compliant.

`autoversion` now outputs what `autoversion HEAD` would have - i.e. make 'HEAD' default arg, rather than erroring 

Also add support for debian style branch/tag names (i.e. `owner/branch` or `owner/tag` - e.g. `debian/dev` or `debian/2.1.4`). As '/' is invalid in a debian version, in the case of multiple slashes, only content after the final slash is used.